### PR TITLE
Devices and external libraries options, make install, Makefile fix 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,6 +73,11 @@ For example, we can define the outline for a ``ComplexPhase`` operator in the ``
         (2) of (L, M) sky coordinates with shape (nsrc, 2)
         (3) of frequencies,
       compute the complex phase with shape (nsrc, ntime, nbl, nchan)
+    devices_compatibilities:
+        - "cpu"
+        - "gpu"
+    extra_libraries_deps:
+        - "m"
 
 We can then run:
 

--- a/README.rst
+++ b/README.rst
@@ -80,6 +80,7 @@ For example, we can define the outline for a ``ComplexPhase`` operator in the ``
         - "gpu"
     extra_libraries_deps:
         - "m"
+    use_old_abi: yes
 
 We can then run:
 
@@ -169,6 +170,17 @@ External libraries can be added to the linker.
     extra_libraries_deps:
         - "opencv"
         - "jpeg"
+
+Note on ``gcc`` version ``>=5``: gcc uses the new C++ ABI since version 5.
+The binary pip packages available on the TensorFlow website are built
+with gcc4 that uses the older ABI. Set the option ``use_old_abi`` with the value ``yes``
+to allow the library to be compatible with the older abi.
+
+.. code:: yaml
+
+    use_old_abi: yes
+
+
 
 Finally operator documentation may also be supplied.
 

--- a/README.rst
+++ b/README.rst
@@ -49,6 +49,8 @@ The user should provide a YAML configuration file defining the operator:
 -  polymorphic type attributes.
 -  other attributes.
 -  documentation.
+-  devices compatibilities.
+-  optional external libraries.
 
 For example, we can define the outline for a ``ComplexPhase`` operator in the ``complex_phase.yml`` file.
 
@@ -151,6 +153,22 @@ generator code as the range of attribute behaviour is complex.
 
     op_other_attrs:
         - "iterations: int32 >= 2",
+
+Sources codes will be generated according to the specified devices.
+
+.. code:: yaml
+
+    devices_compatibilities:
+        - "cpu"
+        - "gpu"
+
+External libraries can be added to the linker.
+
+.. code:: yaml
+
+    extra_libraries_deps:
+        - "opencv"
+        - "jpeg"
 
 Finally operator documentation may also be supplied.
 

--- a/tfopgen/create_op.py
+++ b/tfopgen/create_op.py
@@ -8,7 +8,7 @@ from tfopgen.util import (parse_args, load_config, parse_inout,
 
 def make_template_kwargs(op_name, py_op_name,
                          project, library, op_inputs, op_outputs,
-                         op_type_attrs, op_other_attrs, op_doc, op_libs, op_devices_comps):
+                         op_type_attrs, op_other_attrs, op_doc, op_libs, op_devices_comps, op_abi):
     """
     Creates a dictionary suitable for rendering the jinja2 templates in this package
     """
@@ -63,6 +63,7 @@ def make_template_kwargs(op_name, py_op_name,
         # Building
         'extra_libs': ''.join([' -l'+l for l in op_libs]),
         'op_devices_comps' : op_devices_comps,
+        'op_abi' : op_abi,
     }
 
     template_kwargs.update({
@@ -101,7 +102,8 @@ def run(args):
     op_other_attrs = cfg.get('other_attrs', [])
     op_doc = cfg.get('doc', "Documentation")
     op_libs = cfg.get('extra_libraries_deps',[])
-    op_devices_comps = cfg.get('devices_compatibilities', [])
+    op_devices_comps = cfg.get('devices_compatibilities', ["gpu", "cpu"])
+    op_abi = cfg.get('use_old_abi', "yes")
 
 
     # Parse input ops
@@ -126,7 +128,8 @@ def run(args):
     # Create dictionary for rendering jinja2 templates
     kwargs = make_template_kwargs(op_name, py_op_name,
                                   project, library, op_inputs, op_outputs,
-                                  op_type_attrs, op_other_attrs, op_doc, op_libs, op_devices_comps)
+                                  op_type_attrs, op_other_attrs, op_doc,
+                                  op_libs, op_devices_comps, op_abi)
 
     def render(template, output):
         """ Hook to render template file to output """

--- a/tfopgen/examples/complex_phase.yml
+++ b/tfopgen/examples/complex_phase.yml
@@ -17,3 +17,6 @@ doc: >
     (2) of (L, M) sky coordinates with shape (nsrc, 2)
     (3) of frequencies,
   compute the complex phase with shape (nsrc, ntime, nbl, nchan)
+devices_compatibilities:
+  - "cpu"
+  - "gpu"

--- a/tfopgen/examples/get_slide_patch.yml
+++ b/tfopgen/examples/get_slide_patch.yml
@@ -1,0 +1,19 @@
+---
+project: contextvision_ops
+library: contextvision_ops_lib
+name: GetSlidePatch
+type_attrs:
+  - "IT: {int32, int64}"
+inputs:
+  - ["patches_positions: IT", [null,2]] # (x0, y0)
+  - ["dimension: int32", [2]] # (w,h)
+  - ["tif_files: string", [null,1]] # (file_paths)
+  - ["levels: int32", [null, 1]] # (levels)
+outputs:
+  - ["images: int32", [null, null, null, 4]] # (N, w,h,(ARGB))
+doc: >
+  Get Slide patch
+extra_libraries_deps:
+  - "openslide"
+devices_compatibilities:
+  - "cpu"

--- a/tfopgen/examples/simple.yml
+++ b/tfopgen/examples/simple.yml
@@ -10,4 +10,7 @@ type_attrs:
   - "FT: {float, double} = DT_FLOAT"
 other_attrs: []
 doc: "How now brown cow"
+devices_compatibilities:
+  - "cpu"
+  - "gpu"
 

--- a/tfopgen/templates/Makefile.j2
+++ b/tfopgen/templates/Makefile.j2
@@ -3,7 +3,7 @@ TF_INC=$(shell python -c 'from __future__ import print_function; import tensorfl
 TF_LIB=$(shell python -c 'import tensorflow as tf; print(tf.sysconfig.get_lib())')
 TF_CUDA=$(shell python -c 'from __future__ import print_function; import tensorflow as tf; print(int(tf.test.is_built_with_cuda()))')
 
-TF_FLAGS=-D_MWAITXINTRIN_H_INCLUDED -D_FORCE_INLINES
+TF_FLAGS=-D_MWAITXINTRIN_H_INCLUDED -D_FORCE_INLINES {% if op_abi == "yes"%}-D_GLIBCXX_USE_CXX11_ABI=0{% endif %}
 
 # Dependencies
 DEPDIR:=.d

--- a/tfopgen/templates/Makefile.j2
+++ b/tfopgen/templates/Makefile.j2
@@ -1,8 +1,9 @@
 # Tensorflow includes and defines
 TF_INC=$(shell python -c 'from __future__ import print_function; import tensorflow as tf; print(tf.sysconfig.get_include())')
+TF_LIB=$(shell python -c 'import tensorflow as tf; print(tf.sysconfig.get_lib())')
 TF_CUDA=$(shell python -c 'from __future__ import print_function; import tensorflow as tf; print(int(tf.test.is_built_with_cuda()))')
 
-TF_FLAGS=-D_MWAITXINTRIN_H_INCLUDED -D_FORCE_INLINES -D_GLIBCXX_USE_CXX11_ABI=0
+TF_FLAGS=-D_MWAITXINTRIN_H_INCLUDED -D_FORCE_INLINES
 
 # Dependencies
 DEPDIR:=.d
@@ -21,12 +22,12 @@ OBJECTS=$(addsuffix .o, $(basename $(SOURCES)))
 LIBRARY={{shared_library}}
 
 # Compiler flags
-INCLUDES= -I $(TF_INC)
+INCLUDES= -I $(TF_INC) -I$(TF_INC)/external/nsync/public
 CPPFLAGS=-std=c++11 $(TF_FLAGS) $(INCLUDES) -fPIC -fopenmp -O2 -march=native -mtune=native
 NVCCFLAGS=-std=c++11 -D GOOGLE_CUDA=$(TF_CUDA) $(TF_FLAGS) $(INCLUDES) \
 	-x cu --compiler-options "-fPIC" --gpu-architecture=sm_30 -lineinfo
 
-LDFLAGS = -fPIC -fopenmp
+LDFLAGS = -fPIC -fopenmp -L$(TF_LIB) -ltensorflow_framework{{extra_libs}}
 
 # Compiler directives
 COMPILE.cpp = g++ $(DEPFLAGS) $(CPPFLAGS) -c
@@ -42,6 +43,9 @@ all : $(LIBRARY)
 
 clean :
 	rm -f $(OBJECTS) $(LIBRARY)
+
+install :
+	cp $(LIBRARY) $(TF_LIB)
 
 $(LIBRARY) : $(OBJECTS)
 	g++  -shared $(OBJECTS) -o $(LIBRARY) $(LDFLAGS)

--- a/tfopgen/templates/test_source.j2
+++ b/tfopgen/templates/test_source.j2
@@ -24,7 +24,7 @@ class Test{{op_name}}(unittest.TestCase):
         {% set comma = last_joiner(",") -%}
         type_permutations = [
         {%- for perm in op_np_type_perms %}
-        {{ perm | replace("'", "") | indent(4, True) }}{{comma(loop.last)}}
+        {{ perm[0] | replace("'", "") | indent(4, True) }}{{comma(loop.last)}}
         {%- endfor -%}
         ]
 
@@ -63,18 +63,21 @@ class Test{{op_name}}(unittest.TestCase):
                 return self.{{library}}.{{py_op_name}}(*tf_args)
 
         # Pin operation to CPU
-        cpu_op = _pin_op('/cpu:0', *tf_args)
+        {% if "cpu" not in op_devices_comps %}#{% endif %}cpu_op = _pin_op('/cpu:0', *tf_args)
 
         # Run the op on all GPUs
-        gpu_ops = [_pin_op(d, *tf_args) for d in self.gpu_devs]
+
+        {% if "gpu" not in op_devices_comps %}#{% endif %}gpu_ops = [_pin_op(d, *tf_args) for d in self.gpu_devs]
+
+
 
         # Initialise variables
         init_op = tf.global_variables_initializer()
 
         with tf.Session() as S:
             S.run(init_op)
-            S.run(cpu_op)
-            S.run(gpu_ops)
+            {% if "cpu" not in op_devices_comps %}#{% endif %}S.run(cpu_op)
+            {% if "gpu" not in op_devices_comps %}#{% endif %}S.run(gpu_ops)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
- New features that allow to generate code according to operator's devices compatibility (cpu and/or gpu), and to specify external libraries to be linked.
- The Makefile has been fixed to work with the latest tensorflow version (tested on the version 1.3 built from source).
- Added 'make install' that copies the built library to the tensorflow's library directory.